### PR TITLE
feat: implement Dummy Recognition Services (Issue #3)

### DIFF
--- a/src/backend/NETFace.Attendance.Api/Controllers/EmployeesController.cs
+++ b/src/backend/NETFace.Attendance.Api/Controllers/EmployeesController.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NETFace.Attendance.Api.DTOs;
+using NETFace.Attendance.Domain.Entities;
+using NETFace.Attendance.Infrastructure.Persistence;
+
+namespace NETFace.Attendance.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class EmployeesController : ControllerBase
+{
+    private readonly AppDbContext _context;
+
+    public EmployeesController(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateEmployeeRequest request)
+    {
+        var employee = new Employee(request.EmployeeCode, request.ProfileDetails, request.AdminFlag);
+        
+        _context.Employees.Add(employee);
+        await _context.SaveChangesAsync();
+
+        var response = new EmployeeResponse(
+            employee.Id,
+            employee.EmployeeCode,
+            employee.ProfileDetails,
+            employee.Status.ToString(),
+            employee.AdminFlag,
+            employee.FaceEmbeddings.Count
+        );
+
+        return CreatedAtAction(nameof(Get), new { id = employee.Id }, response);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(Guid id)
+    {
+        var employee = await _context.Employees
+            .Include(e => e.FaceEmbeddings)
+            .FirstOrDefaultAsync(e => e.Id == id);
+
+        if (employee == null) return NotFound();
+
+        var response = new EmployeeResponse(
+            employee.Id,
+            employee.EmployeeCode,
+            employee.ProfileDetails,
+            employee.Status.ToString(),
+            employee.AdminFlag,
+            employee.FaceEmbeddings.Count
+        );
+
+        return Ok(response);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> List()
+    {
+        var employees = await _context.Employees
+            .Include(e => e.FaceEmbeddings)
+            .Select(e => new EmployeeResponse(
+                e.Id,
+                e.EmployeeCode,
+                e.ProfileDetails,
+                e.Status.ToString(),
+                e.AdminFlag,
+                e.FaceEmbeddings.Count
+            ))
+            .ToListAsync();
+
+        return Ok(employees);
+    }
+}

--- a/src/backend/NETFace.Attendance.Api/DTOs/CreateEmployeeRequest.cs
+++ b/src/backend/NETFace.Attendance.Api/DTOs/CreateEmployeeRequest.cs
@@ -1,0 +1,3 @@
+namespace NETFace.Attendance.Api.DTOs;
+
+public record CreateEmployeeRequest(string EmployeeCode, string ProfileDetails, bool AdminFlag);

--- a/src/backend/NETFace.Attendance.Api/DTOs/EmployeeResponse.cs
+++ b/src/backend/NETFace.Attendance.Api/DTOs/EmployeeResponse.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NETFace.Attendance.Api.DTOs;
+
+public record EmployeeResponse(
+    Guid Id,
+    string EmployeeCode,
+    string ProfileDetails,
+    string Status,
+    bool AdminFlag,
+    int EmbeddingsCount
+);

--- a/src/backend/NETFace.Attendance.Api/NETFace.Attendance.Api.csproj
+++ b/src/backend/NETFace.Attendance.Api/NETFace.Attendance.Api.csproj
@@ -5,6 +5,13 @@
     <ProjectReference Include="..\NETFace.Attendance.Infrastructure\NETFace.Attendance.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/backend/NETFace.Attendance.Api/Program.cs
+++ b/src/backend/NETFace.Attendance.Api/Program.cs
@@ -1,9 +1,13 @@
 using Microsoft.EntityFrameworkCore;
+using NETFace.Attendance.Infrastructure;
 using NETFace.Attendance.Infrastructure.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+
+// Register Recognition Services (dummy services for ML/AI abstraction)
+builder.Services.AddRecognitionServices(builder.Configuration);
 
 // We register DbContext here.
 builder.Services.AddDbContext<AppDbContext>(options =>

--- a/src/backend/NETFace.Attendance.Api/Program.cs
+++ b/src/backend/NETFace.Attendance.Api/Program.cs
@@ -1,5 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using NETFace.Attendance.Infrastructure.Persistence;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+// We register DbContext here.
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Host=localhost;Database=NETFace_Attendance;Username=postgres;Password=postgres"));
 
 var app = builder.Build();
 
+app.MapControllers();
+
 app.Run();
+
+public partial class Program { }

--- a/src/backend/NETFace.Attendance.Application/Interfaces/FaceDetectionResult.cs
+++ b/src/backend/NETFace.Attendance.Application/Interfaces/FaceDetectionResult.cs
@@ -1,0 +1,3 @@
+namespace NETFace.Attendance.Application.Interfaces;
+
+public record FaceDetectionResult(bool FaceDetected, int FaceCount = 1);

--- a/src/backend/NETFace.Attendance.Application/Interfaces/FaceMatchResult.cs
+++ b/src/backend/NETFace.Attendance.Application/Interfaces/FaceMatchResult.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NETFace.Attendance.Application.Interfaces;
+
+public record FaceMatchResult(
+    bool IsMatch,
+    double Distance,
+    Guid? MatchedEmployeeId = null);

--- a/src/backend/NETFace.Attendance.Application/Interfaces/IFaceDetectionService.cs
+++ b/src/backend/NETFace.Attendance.Application/Interfaces/IFaceDetectionService.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NETFace.Attendance.Application.Interfaces;
+
+public interface IFaceDetectionService
+{
+    Task<FaceDetectionResult> DetectFacesAsync(byte[] imageBytes, CancellationToken cancellationToken = default);
+}

--- a/src/backend/NETFace.Attendance.Application/Interfaces/IFaceEmbeddingExtractor.cs
+++ b/src/backend/NETFace.Attendance.Application/Interfaces/IFaceEmbeddingExtractor.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NETFace.Attendance.Application.Interfaces;
+
+public interface IFaceEmbeddingExtractor
+{
+    Task<float[]> ExtractEmbeddingAsync(byte[] imageBytes, CancellationToken cancellationToken = default);
+}

--- a/src/backend/NETFace.Attendance.Application/Interfaces/IFaceMatchingService.cs
+++ b/src/backend/NETFace.Attendance.Application/Interfaces/IFaceMatchingService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using NETFace.Attendance.Domain.Entities;
+
+namespace NETFace.Attendance.Application.Interfaces;
+
+public interface IFaceMatchingService
+{
+    double CalculateDistance(float[] vectorA, float[] vectorB);
+    FaceMatchResult Match(float[] vectorA, float[] vectorB, double? threshold = null);
+    FaceMatchResult FindBestMatch(float[] targetVector, IEnumerable<FaceEmbedding> candidates, double? threshold = null);
+}

--- a/src/backend/NETFace.Attendance.Domain/Entities/Employee.cs
+++ b/src/backend/NETFace.Attendance.Domain/Entities/Employee.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using NETFace.Attendance.Domain.Enums;
+using NETFace.Attendance.Domain.Exceptions;
+
+namespace NETFace.Attendance.Domain.Entities;
+
+public class Employee
+{
+    public Guid Id { get; private set; }
+    public string EmployeeCode { get; private set; } = string.Empty;
+    public string ProfileDetails { get; private set; } = string.Empty;
+    public EmployeeStatus Status { get; private set; }
+    public bool AdminFlag { get; private set; }
+
+    private readonly List<FaceEmbedding> _faceEmbeddings = new();
+    public IReadOnlyCollection<FaceEmbedding> FaceEmbeddings => _faceEmbeddings.AsReadOnly();
+
+    // EF Core constructor
+    private Employee() { }
+
+    public Employee(string employeeCode, string profileDetails, bool adminFlag)
+    {
+        Id = Guid.NewGuid();
+        EmployeeCode = employeeCode ?? throw new ArgumentNullException(nameof(employeeCode));
+        ProfileDetails = profileDetails ?? throw new ArgumentNullException(nameof(profileDetails));
+        AdminFlag = adminFlag;
+        Status = EmployeeStatus.Active;
+    }
+
+    public void AddFaceEmbedding(float[] vector)
+    {
+        if (_faceEmbeddings.Count >= 5)
+        {
+            throw new MaxFaceEmbeddingsReachedException("An employee can have a maximum of 5 face embeddings.");
+        }
+        
+        _faceEmbeddings.Add(new FaceEmbedding(this.Id, vector));
+    }
+}

--- a/src/backend/NETFace.Attendance.Domain/Entities/FaceEmbedding.cs
+++ b/src/backend/NETFace.Attendance.Domain/Entities/FaceEmbedding.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace NETFace.Attendance.Domain.Entities;
+
+public class FaceEmbedding
+{
+    public Guid Id { get; private set; }
+    public Guid EmployeeId { get; private set; }
+    public float[] Vector { get; private set; }
+    public DateTimeOffset CapturedAt { get; private set; }
+
+    // EF Core constructor
+    private FaceEmbedding() { Vector = Array.Empty<float>(); }
+
+    internal FaceEmbedding(Guid employeeId, float[] vector)
+    {
+        Id = Guid.NewGuid();
+        EmployeeId = employeeId;
+        Vector = vector ?? throw new ArgumentNullException(nameof(vector));
+        CapturedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/backend/NETFace.Attendance.Domain/Enums/EmployeeStatus.cs
+++ b/src/backend/NETFace.Attendance.Domain/Enums/EmployeeStatus.cs
@@ -1,0 +1,7 @@
+namespace NETFace.Attendance.Domain.Enums;
+
+public enum EmployeeStatus
+{
+    Inactive = 0,
+    Active = 1
+}

--- a/src/backend/NETFace.Attendance.Domain/Exceptions/DomainException.cs
+++ b/src/backend/NETFace.Attendance.Domain/Exceptions/DomainException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace NETFace.Attendance.Domain.Exceptions;
+
+public abstract class DomainException : Exception
+{
+    protected DomainException(string message) : base(message)
+    {
+    }
+}

--- a/src/backend/NETFace.Attendance.Domain/Exceptions/MaxFaceEmbeddingsReachedException.cs
+++ b/src/backend/NETFace.Attendance.Domain/Exceptions/MaxFaceEmbeddingsReachedException.cs
@@ -1,0 +1,8 @@
+namespace NETFace.Attendance.Domain.Exceptions;
+
+public class MaxFaceEmbeddingsReachedException : DomainException
+{
+    public MaxFaceEmbeddingsReachedException(string message) : base(message)
+    {
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/DependencyInjection.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NETFace.Attendance.Application.Interfaces;
+using NETFace.Attendance.Infrastructure.Services.Recognition;
+
+namespace NETFace.Attendance.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddRecognitionServices(this IServiceCollection services, IConfiguration? configuration = null)
+    {
+        var options = new FaceMatchingOptions();
+        var thresholdValue = configuration?["FaceMatching:MatchThreshold"];
+        if (double.TryParse(thresholdValue, System.Globalization.CultureInfo.InvariantCulture, out double parsedThreshold))
+        {
+            options.MatchThreshold = parsedThreshold;
+        }
+
+        services.AddSingleton(options);
+        services.AddScoped<IFaceDetectionService, DummyFaceDetectionService>();
+        services.AddScoped<IFaceEmbeddingExtractor, DummyFaceEmbeddingExtractor>();
+        services.AddScoped<IFaceMatchingService, DummyFaceMatchingService>();
+
+        return services;
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/NETFace.Attendance.Infrastructure.csproj
+++ b/src/backend/NETFace.Attendance.Infrastructure/NETFace.Attendance.Infrastructure.csproj
@@ -5,6 +5,11 @@
     <ProjectReference Include="..\NETFace.Attendance.Domain\NETFace.Attendance.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/backend/NETFace.Attendance.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using NETFace.Attendance.Domain.Entities;
+
+namespace NETFace.Attendance.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Employee> Employees => Set<Employee>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NETFace.Attendance.Domain.Entities;
+
+namespace NETFace.Attendance.Infrastructure.Persistence.Configurations;
+
+public class EmployeeConfiguration : IEntityTypeConfiguration<Employee>
+{
+    public void Configure(EntityTypeBuilder<Employee> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.EmployeeCode)
+            .IsRequired()
+            .HasMaxLength(50);
+        
+        builder.HasIndex(e => e.EmployeeCode)
+            .IsUnique();
+
+        builder.Property(e => e.ProfileDetails)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Status)
+            .IsRequired();
+
+        builder.Property(e => e.AdminFlag)
+            .IsRequired();
+
+        builder.OwnsMany(e => e.FaceEmbeddings, fe => 
+        {
+            fe.ToTable("FaceEmbeddings");
+            fe.HasKey(f => f.Id);
+            fe.WithOwner().HasForeignKey(f => f.EmployeeId);
+            
+            fe.Property(f => f.Vector)
+                .IsRequired();
+
+            fe.Property(f => f.CapturedAt)
+                .IsRequired();
+        });
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceDetectionService.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceDetectionService.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NETFace.Attendance.Application.Interfaces;
+
+namespace NETFace.Attendance.Infrastructure.Services.Recognition;
+
+public class DummyFaceDetectionService : IFaceDetectionService
+{
+    public Task<FaceDetectionResult> DetectFacesAsync(byte[] imageBytes, CancellationToken cancellationToken = default)
+    {
+        if (imageBytes == null || imageBytes.Length == 0)
+        {
+            return Task.FromResult(new FaceDetectionResult(FaceDetected: false, FaceCount: 0));
+        }
+
+        return Task.FromResult(new FaceDetectionResult(FaceDetected: true, FaceCount: 1));
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceEmbeddingExtractor.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceEmbeddingExtractor.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using NETFace.Attendance.Application.Interfaces;
+
+namespace NETFace.Attendance.Infrastructure.Services.Recognition;
+
+public class DummyFaceEmbeddingExtractor : IFaceEmbeddingExtractor
+{
+    private const int EmbeddingDimension = 128;
+
+    public Task<float[]> ExtractEmbeddingAsync(byte[] imageBytes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(imageBytes);
+
+        if (imageBytes.Length == 0)
+        {
+            throw new ArgumentException("Image data cannot be empty.", nameof(imageBytes));
+        }
+
+        // Generate a deterministic 128-d normalized float vector from image bytes for consistent testing
+        byte[] hash = SHA256.HashData(imageBytes);
+        float[] embedding = new float[EmbeddingDimension];
+
+        for (int i = 0; i < EmbeddingDimension; i++)
+        {
+            byte b = hash[i % hash.Length];
+            embedding[i] = (float)b / byte.MaxValue;
+        }
+
+        return Task.FromResult(embedding);
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceMatchingService.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/DummyFaceMatchingService.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using NETFace.Attendance.Application.Interfaces;
+using NETFace.Attendance.Domain.Entities;
+
+namespace NETFace.Attendance.Infrastructure.Services.Recognition;
+
+public class DummyFaceMatchingService : IFaceMatchingService
+{
+    private readonly double _defaultThreshold;
+
+    public DummyFaceMatchingService(FaceMatchingOptions? options = null)
+    {
+        _defaultThreshold = options?.MatchThreshold ?? 0.6;
+    }
+
+    public double CalculateDistance(float[] vectorA, float[] vectorB)
+    {
+        ArgumentNullException.ThrowIfNull(vectorA);
+        ArgumentNullException.ThrowIfNull(vectorB);
+
+        if (vectorA.Length == 0)
+        {
+            throw new ArgumentException("Vector cannot be empty.", nameof(vectorA));
+        }
+
+        if (vectorA.Length != vectorB.Length)
+        {
+            throw new ArgumentException("Vector dimensions must match.", nameof(vectorB));
+        }
+
+        double sum = 0.0;
+        for (int i = 0; i < vectorA.Length; i++)
+        {
+            double diff = vectorA[i] - vectorB[i];
+            sum += diff * diff;
+        }
+
+        return Math.Sqrt(sum);
+    }
+
+    public FaceMatchResult Match(float[] vectorA, float[] vectorB, double? threshold = null)
+    {
+        double distance = CalculateDistance(vectorA, vectorB);
+        double effectiveThreshold = threshold ?? _defaultThreshold;
+        bool isMatch = distance <= effectiveThreshold;
+
+        return new FaceMatchResult(isMatch, distance);
+    }
+
+    public FaceMatchResult FindBestMatch(float[] targetVector, IEnumerable<FaceEmbedding> candidates, double? threshold = null)
+    {
+        ArgumentNullException.ThrowIfNull(targetVector);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        double effectiveThreshold = threshold ?? _defaultThreshold;
+        double minDistance = double.MaxValue;
+        Guid? matchedEmployeeId = null;
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate?.Vector == null)
+            {
+                continue;
+            }
+
+            double distance = CalculateDistance(targetVector, candidate.Vector);
+            if (distance < minDistance)
+            {
+                minDistance = distance;
+                matchedEmployeeId = candidate.EmployeeId;
+            }
+        }
+
+        bool isMatch = matchedEmployeeId.HasValue && minDistance <= effectiveThreshold;
+
+        return new FaceMatchResult(
+            isMatch,
+            matchedEmployeeId.HasValue ? minDistance : double.PositiveInfinity,
+            isMatch ? matchedEmployeeId : null);
+    }
+}

--- a/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/FaceMatchingOptions.cs
+++ b/src/backend/NETFace.Attendance.Infrastructure/Services/Recognition/FaceMatchingOptions.cs
@@ -1,0 +1,6 @@
+namespace NETFace.Attendance.Infrastructure.Services.Recognition;
+
+public class FaceMatchingOptions
+{
+    public double MatchThreshold { get; set; } = 0.6;
+}

--- a/tests/NETFace.Attendance.Api.Tests/Api/EmployeesControllerTests.cs
+++ b/tests/NETFace.Attendance.Api.Tests/Api/EmployeesControllerTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NETFace.Attendance.Infrastructure.Persistence;
+using Xunit;
+
+namespace NETFace.Attendance.Api.Tests.Api;
+
+public class EmployeesControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public EmployeesControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddDbContext<AppDbContext>(options =>
+                {
+                    options.UseInMemoryDatabase("InMemoryDbForTesting");
+                });
+            });
+        });
+    }
+
+    [Fact]
+    public async Task CreateEmployee_ReturnsCreatedEmployee()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var request = new
+        {
+            EmployeeCode = "TEST-001",
+            ProfileDetails = "Test Employee",
+            AdminFlag = false
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/employees", request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        Assert.Contains("TEST-001", responseString);
+    }
+}

--- a/tests/NETFace.Attendance.Api.Tests/Domain/EmployeeTests.cs
+++ b/tests/NETFace.Attendance.Api.Tests/Domain/EmployeeTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Xunit;
+using NETFace.Attendance.Domain.Entities;
+using NETFace.Attendance.Domain.Enums;
+using NETFace.Attendance.Domain.Exceptions;
+
+namespace NETFace.Attendance.Api.Tests.Domain;
+
+public class EmployeeTests
+{
+    [Fact]
+    public void Constructor_ShouldInitializeWithActiveStatus()
+    {
+        // Arrange & Act
+        var employee = new Employee("EMP-001", "John Doe", false);
+
+        // Assert
+        Assert.Equal(EmployeeStatus.Active, employee.Status);
+        Assert.Equal("EMP-001", employee.EmployeeCode);
+        Assert.Equal("John Doe", employee.ProfileDetails);
+        Assert.False(employee.AdminFlag);
+        Assert.NotEqual(Guid.Empty, employee.Id);
+        Assert.Empty(employee.FaceEmbeddings);
+    }
+
+    [Fact]
+    public void AddFaceEmbedding_WhenLimitNotReached_ShouldAddEmbedding()
+    {
+        // Arrange
+        var employee = new Employee("EMP-001", "John Doe", false);
+        var vector = new float[] { 0.1f, 0.2f, 0.3f };
+
+        // Act
+        employee.AddFaceEmbedding(vector);
+
+        // Assert
+        Assert.Single(employee.FaceEmbeddings);
+    }
+
+    [Fact]
+    public void AddFaceEmbedding_WhenLimitReached_ShouldThrowException()
+    {
+        // Arrange
+        var employee = new Employee("EMP-001", "John Doe", false);
+        for (int i = 0; i < 5; i++)
+        {
+            employee.AddFaceEmbedding(new float[] { 0.1f, 0.2f, 0.3f });
+        }
+
+        // Act & Assert
+        var exception = Assert.Throws<MaxFaceEmbeddingsReachedException>(() => 
+            employee.AddFaceEmbedding(new float[] { 0.4f, 0.5f, 0.6f })
+        );
+
+        Assert.Equal("An employee can have a maximum of 5 face embeddings.", exception.Message);
+    }
+}

--- a/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceDetectionAndExtractionTests.cs
+++ b/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceDetectionAndExtractionTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using NETFace.Attendance.Application.Interfaces;
+using NETFace.Attendance.Infrastructure.Services.Recognition;
+using Xunit;
+
+namespace NETFace.Attendance.Api.Tests.Infrastructure;
+
+public class DummyFaceDetectionAndExtractionTests
+{
+    [Fact]
+    public async Task DummyFaceDetection_WithValidBytes_ReturnsDetectedTrue()
+    {
+        IFaceDetectionService service = new DummyFaceDetectionService();
+        byte[] dummyImage = [1, 2, 3, 4];
+
+        var result = await service.DetectFacesAsync(dummyImage);
+
+        Assert.True(result.FaceDetected);
+        Assert.Equal(1, result.FaceCount);
+    }
+
+    [Fact]
+    public async Task DummyFaceDetection_WithEmptyOrNullBytes_ReturnsDetectedFalse()
+    {
+        IFaceDetectionService service = new DummyFaceDetectionService();
+
+        var resultEmpty = await service.DetectFacesAsync([]);
+        var resultNull = await service.DetectFacesAsync(null!);
+
+        Assert.False(resultEmpty.FaceDetected);
+        Assert.Equal(0, resultEmpty.FaceCount);
+        Assert.False(resultNull.FaceDetected);
+        Assert.Equal(0, resultNull.FaceCount);
+    }
+
+    [Fact]
+    public async Task DummyFaceEmbeddingExtractor_WithValidBytes_Returns128DimensionVector()
+    {
+        IFaceEmbeddingExtractor extractor = new DummyFaceEmbeddingExtractor();
+        byte[] dummyImage = [10, 20, 30];
+
+        var vector = await extractor.ExtractEmbeddingAsync(dummyImage);
+
+        Assert.NotNull(vector);
+        Assert.Equal(128, vector.Length);
+    }
+
+    [Fact]
+    public async Task DummyFaceEmbeddingExtractor_WithSameBytes_ReturnsDeterministicVector()
+    {
+        IFaceEmbeddingExtractor extractor = new DummyFaceEmbeddingExtractor();
+        byte[] dummyImageA = [10, 20, 30];
+        byte[] dummyImageB = [10, 20, 30];
+
+        var vectorA = await extractor.ExtractEmbeddingAsync(dummyImageA);
+        var vectorB = await extractor.ExtractEmbeddingAsync(dummyImageB);
+
+        Assert.Equal(vectorA, vectorB);
+    }
+
+    [Fact]
+    public async Task DummyFaceEmbeddingExtractor_WithEmptyBytes_ThrowsArgumentException()
+    {
+        IFaceEmbeddingExtractor extractor = new DummyFaceEmbeddingExtractor();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => extractor.ExtractEmbeddingAsync([]));
+    }
+}

--- a/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceDetectionAndExtractionTests.cs
+++ b/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceDetectionAndExtractionTests.cs
@@ -66,4 +66,12 @@ public class DummyFaceDetectionAndExtractionTests
 
         await Assert.ThrowsAsync<ArgumentException>(() => extractor.ExtractEmbeddingAsync([]));
     }
+
+    [Fact]
+    public async Task DummyFaceEmbeddingExtractor_WithNullBytes_ThrowsArgumentNullException()
+    {
+        IFaceEmbeddingExtractor extractor = new DummyFaceEmbeddingExtractor();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => extractor.ExtractEmbeddingAsync(null!));
+    }
 }

--- a/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceMatchingServiceTests.cs
+++ b/tests/NETFace.Attendance.Api.Tests/Infrastructure/DummyFaceMatchingServiceTests.cs
@@ -1,0 +1,190 @@
+using System;
+using NETFace.Attendance.Application.Interfaces;
+using NETFace.Attendance.Infrastructure.Services.Recognition;
+using Xunit;
+
+namespace NETFace.Attendance.Api.Tests.Infrastructure;
+
+public class DummyFaceMatchingServiceTests
+{
+    private readonly IFaceMatchingService _sut = new DummyFaceMatchingService();
+
+    [Fact]
+    public void CalculateDistance_WithIdenticalVectors_ReturnsZero()
+    {
+        // Arrange
+        float[] vectorA = [0.1f, 0.5f, 0.9f];
+        float[] vectorB = [0.1f, 0.5f, 0.9f];
+
+        // Act
+        double distance = _sut.CalculateDistance(vectorA, vectorB);
+
+        // Assert
+        Assert.Equal(0.0, distance, precision: 5);
+    }
+
+    [Fact]
+    public void CalculateDistance_WithKnownVectors_ReturnsExpectedEuclideanDistance()
+    {
+        // Arrange
+        // Distance between (0, 0) and (3, 4) in 2D space is sqrt(3^2 + 4^2) = 5
+        float[] vectorA = [0.0f, 0.0f];
+        float[] vectorB = [3.0f, 4.0f];
+
+        // Act
+        double distance = _sut.CalculateDistance(vectorA, vectorB);
+
+        // Assert
+        Assert.Equal(5.0, distance, precision: 5);
+    }
+
+    [Fact]
+    public void Match_WithIdenticalVectors_ReturnsMatchTrue()
+    {
+        // Arrange
+        float[] vectorA = [0.2f, 0.4f, 0.6f];
+        float[] vectorB = [0.2f, 0.4f, 0.6f];
+
+        // Act
+        var result = _sut.Match(vectorA, vectorB);
+
+        // Assert
+        Assert.True(result.IsMatch);
+        Assert.Equal(0.0, result.Distance, precision: 5);
+    }
+
+    [Fact]
+    public void Match_WithDrasticallyDifferentVectors_ReturnsMatchFalse()
+    {
+        // Arrange
+        float[] vectorA = [0.0f, 0.0f, 0.0f];
+        float[] vectorB = [1.0f, 1.0f, 1.0f]; // Distance is sqrt(3) ~ 1.732 > 0.6 default threshold
+
+        // Act
+        var result = _sut.Match(vectorA, vectorB);
+
+        // Assert
+        Assert.False(result.IsMatch);
+        Assert.True(result.Distance > 0.6);
+    }
+
+    [Fact]
+    public void Match_WithConfigurableThreshold_AppliesThresholdAccurately()
+    {
+        // Arrange
+        // Distance is sqrt(0.3^2 + 0.4^2) = 0.5
+        float[] vectorA = [0.0f, 0.0f];
+        float[] vectorB = [0.3f, 0.4f];
+
+        // Act & Assert with explicit threshold override
+        var matchStrict = _sut.Match(vectorA, vectorB, threshold: 0.4);
+        var matchRelaxed = _sut.Match(vectorA, vectorB, threshold: 0.6);
+
+        Assert.False(matchStrict.IsMatch);
+        Assert.Equal(0.5, matchStrict.Distance, precision: 5);
+
+        Assert.True(matchRelaxed.IsMatch);
+        Assert.Equal(0.5, matchRelaxed.Distance, precision: 5);
+    }
+
+    [Fact]
+    public void Match_WithConfiguredOptions_UsesOptionsThreshold()
+    {
+        // Arrange
+        var customService = new DummyFaceMatchingService(new FaceMatchingOptions { MatchThreshold = 0.4 });
+        float[] vectorA = [0.0f, 0.0f];
+        float[] vectorB = [0.3f, 0.4f]; // Distance is 0.5 > 0.4
+
+        // Act
+        var result = customService.Match(vectorA, vectorB);
+
+        // Assert
+        Assert.False(result.IsMatch);
+    }
+
+    [Fact]
+    public void FindBestMatch_WithClosestCandidateWithinThreshold_ReturnsBestMatch()
+    {
+        // Arrange
+        var employee1 = new NETFace.Attendance.Domain.Entities.Employee("EMP-001", "Alice", false);
+        employee1.AddFaceEmbedding([0.1f, 0.1f]);
+
+        var employee2 = new NETFace.Attendance.Domain.Entities.Employee("EMP-002", "Bob", false);
+        employee2.AddFaceEmbedding([0.9f, 0.9f]);
+
+        var candidates = new[] { employee1.FaceEmbeddings.First(), employee2.FaceEmbeddings.First() };
+        float[] queryVector = [0.12f, 0.11f]; // Closest to employee1
+
+        // Act
+        var result = _sut.FindBestMatch(queryVector, candidates);
+
+        // Assert
+        Assert.True(result.IsMatch);
+        Assert.Equal(employee1.Id, result.MatchedEmployeeId);
+        Assert.True(result.Distance < 0.1);
+    }
+
+    [Fact]
+    public void FindBestMatch_WhenAllCandidatesExceedThreshold_ReturnsNoMatch()
+    {
+        // Arrange
+        var employee1 = new NETFace.Attendance.Domain.Entities.Employee("EMP-001", "Alice", false);
+        employee1.AddFaceEmbedding([0.8f, 0.8f]);
+
+        var candidates = new[] { employee1.FaceEmbeddings.First() };
+        float[] queryVector = [0.0f, 0.0f]; // Distance ~ 1.13 > 0.6
+
+        // Act
+        var result = _sut.FindBestMatch(queryVector, candidates);
+
+        // Assert
+        Assert.False(result.IsMatch);
+        Assert.Null(result.MatchedEmployeeId);
+    }
+
+    [Fact]
+    public void FindBestMatch_WithEmptyCandidates_ReturnsNoMatch()
+    {
+        // Arrange
+        float[] queryVector = [0.1f, 0.2f];
+        var emptyCandidates = Array.Empty<NETFace.Attendance.Domain.Entities.FaceEmbedding>();
+
+        // Act
+        var result = _sut.FindBestMatch(queryVector, emptyCandidates);
+
+        // Assert
+        Assert.False(result.IsMatch);
+        Assert.Null(result.MatchedEmployeeId);
+    }
+
+    [Fact]
+    public void CalculateDistance_WithNullVector_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _sut.CalculateDistance(null!, [0.1f]));
+        Assert.Throws<ArgumentNullException>(() => _sut.CalculateDistance([0.1f], null!));
+    }
+
+    [Fact]
+    public void CalculateDistance_WithEmptyVector_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _sut.CalculateDistance([], []));
+    }
+
+    [Fact]
+    public void CalculateDistance_WithMismatchedDimensions_ThrowsArgumentException()
+    {
+        float[] vectorA = [0.1f, 0.2f];
+        float[] vectorB = [0.1f, 0.2f, 0.3f];
+
+        Assert.Throws<ArgumentException>(() => _sut.CalculateDistance(vectorA, vectorB));
+    }
+
+    [Fact]
+    public void FindBestMatch_WithNullArguments_ThrowsArgumentNullException()
+    {
+        var candidates = Array.Empty<NETFace.Attendance.Domain.Entities.FaceEmbedding>();
+
+        Assert.Throws<ArgumentNullException>(() => _sut.FindBestMatch(null!, candidates));
+        Assert.Throws<ArgumentNullException>(() => _sut.FindBestMatch([0.1f], null!));
+    }
+}

--- a/tests/NETFace.Attendance.Api.Tests/NETFace.Attendance.Api.Tests.csproj
+++ b/tests/NETFace.Attendance.Api.Tests/NETFace.Attendance.Api.Tests.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
@@ -22,6 +24,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\backend\NETFace.Attendance.Api\NETFace.Attendance.Api.csproj" />
+    <ProjectReference Include="..\..\src\backend\NETFace.Attendance.Domain\NETFace.Attendance.Domain.csproj" />
+    <ProjectReference Include="..\..\src\backend\NETFace.Attendance.Application\NETFace.Attendance.Application.csproj" />
+    <ProjectReference Include="..\..\src\backend\NETFace.Attendance.Infrastructure\NETFace.Attendance.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of Changes
- Defined recognition service interfaces in \NETFace.Attendance.Application\:
  - \IFaceDetectionService\
  - \IFaceEmbeddingExtractor\
  - \IFaceMatchingService\
- Implemented dummy concrete services in \NETFace.Attendance.Infrastructure\:
  - \DummyFaceDetectionService\
  - \DummyFaceEmbeddingExtractor\ (deterministic 128-d vectors via SHA256)
  - \DummyFaceMatchingService\ (Euclidean distance computation with configurable threshold via \FaceMatchingOptions\)
- Registered services via \AddRecognitionServices\ extension method in Infrastructure DI and \Program.cs\.
- Added comprehensive unit tests in \NETFace.Attendance.Api.Tests\.

Closes #3